### PR TITLE
Unlock and progress sounds, progress notification intervals

### DIFF
--- a/cvarinfo.txt
+++ b/cvarinfo.txt
@@ -3,5 +3,6 @@ user int sa_horizontal_position = 1;
 user int sa_animation_type      = 0;
 
 user bool sa_notification_enabled = true;
+user bool sa_sound_enabled        = true;
 
 nosave string sa_achievements = "";

--- a/language.txt
+++ b/language.txt
@@ -21,6 +21,7 @@ SA_CLEAR      = "Clear achievements";
 SA_TEST       = "Show test achievement";
 
 SA_NOTIFY           = "Notifications";
+SA_SOUND            = "Notification sound";
 SA_SLIDE_VERTICAL   = "Slide vertically";
 SA_SLIDE_HORIZONTAL = "Slide horizontally";
 SA_FADE_IN_OUT      = "Fade in/fade out";

--- a/menudef.txt
+++ b/menudef.txt
@@ -20,6 +20,7 @@ OptionMenu sa_Options
   Option "$SA_HORIZONTAL", sa_horizontal_position, sa_HorizontalPositionValues
   Option "$SA_VERTICAL"  , sa_vertical_position,   sa_VerticalPositionValues
   Option "$SA_ANIMATION" , sa_animation_type,      sa_AnimationValues
+  Option "$SA_SOUND"     , sa_sound_enabled,       OnOff
 
   StaticText ""
   Command "$SA_TEST", sa_test

--- a/zscript/ImpAchievements.zs
+++ b/zscript/ImpAchievements.zs
@@ -101,6 +101,7 @@ class ia_OneKill : sa_Achievement
     sa_Achievement.boxColor    0xFFFFFF;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
   }
 }
 
@@ -115,6 +116,7 @@ class ia_TenKills : sa_Achievement
     sa_Achievement.boxColor    0xDDDD22;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
   }
 }
 
@@ -129,6 +131,7 @@ class ia_100Kills : sa_Achievement
     sa_Achievement.boxColor    0xDD2222;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
   }
 }
 
@@ -143,6 +146,7 @@ class ia_666Kills : sa_Achievement
     sa_Achievement.boxColor    0x990000;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
   }
 }
 
@@ -157,6 +161,7 @@ class ia_Telefrag : sa_Achievement
     sa_Achievement.isHidden true;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
   }
 }
 
@@ -172,6 +177,7 @@ class ia_Friend : sa_Achievement
     sa_Achievement.boxColor    0x00AA00;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
   }
 }
 
@@ -183,6 +189,7 @@ class ia_Overkill : sa_Achievement
     sa_Achievement.description "Kill an imp more than usual";
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
   }
 }
 
@@ -195,5 +202,7 @@ class ia_Melee : sa_Achievement
     sa_Achievement.limit 100;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
+    sa_Achievement.unlockSound "misc/secret";
+    sa_Achievement.progressSound "misc/chat";
   }
 }

--- a/zscript/ImpAchievements.zs
+++ b/zscript/ImpAchievements.zs
@@ -200,6 +200,8 @@ class ia_Melee : sa_Achievement
     sa_Achievement.name "Come closer";
     sa_Achievement.description "Hit imps 100 times with melee attack";
     sa_Achievement.limit 100;
+    sa_Achievement.isProgressVisible true;
+    sa_Achievement.isProgressVisibleInterval 10;
     sa_Achievement.lockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockedIcon "graphics/sa_icon.png";
     sa_Achievement.unlockSound "misc/secret";

--- a/zscript/StupidAchievements.zs
+++ b/zscript/StupidAchievements.zs
@@ -116,6 +116,10 @@ class sa_Achievement : Actor abstract
     sa_Achievement.lockedIcon "";
     sa_Achievement.unlockedIcon "";
 
+    // Achievement sound (optional)
+    sa_Achievement.unlockSound "";
+    sa_Achievement.progressSound "";
+
     // Text color. See Font struct for available colors.
     sa_Achievement.textColor Font.CR_White;
 
@@ -326,6 +330,9 @@ extend class sa_Achievement
   String lockedIcon;
   String unlockedIcon;
 
+  String unlockSound;
+  String progressSound;
+
   property title         : title;
   property name          : name;
   property description   : description;
@@ -344,6 +351,8 @@ extend class sa_Achievement
   property isHidden      : isHidden;
   property lockedIcon    : lockedIcon;
   property unlockedIcon  : unlockedIcon;
+  property unlockSound   : unlockSound;
+  property progressSound : progressSound;
 
 } // class sa_Achievement
 
@@ -391,6 +400,14 @@ class sa_ // namespace
     return isLocked
       ? TexMan.checkForTexture(achievement.lockedIcon, TexMan.Type_Any)
       : TexMan.checkForTexture(achievement.unlockedIcon, TexMan.Type_Any);
+  }
+
+  static
+  String switchSound(readonly<sa_Achievement> achievement, bool isLocked)
+  {
+    return isLocked
+      ? achievement.progressSound
+      : achievement.unlockSound;
   }
 
   static
@@ -489,6 +506,7 @@ class sa_Task abstract
 
   void start()
   {
+    S_StartSound(mSound,CHAN_AUTO,CHANF_UI);
     mBirthTime = level.time;
   }
 
@@ -501,6 +519,7 @@ class sa_Task abstract
     mFont    = achievement.fontName;
     mTexture = TexMan.checkForTexture(achievement.texture, TexMan.Type_Any);
     mIcon    = sa_.switchIcon(achievement, isProgress);
+    mSound   = sa_.switchSound(achievement, isProgress);
 
     mHorizontalPositionCvar = sa_Cvar.of("sa_horizontal_position");
     mVerticalPositionCvar   = sa_Cvar.of("sa_vertical_position");
@@ -513,6 +532,7 @@ class sa_Task abstract
   protected String    mFont;
   protected TextureID mTexture;
   protected TextureID mIcon;
+  protected String    mSound;
 
   protected int mBirthTime;
 

--- a/zscript/StupidAchievements.zs
+++ b/zscript/StupidAchievements.zs
@@ -83,7 +83,10 @@ class sa_Achievement : Actor abstract
     sa_Achievement.progressTitle "$SA_PROGRESS";
 
     // True if a notification is shown each time this achievement progress advances.
+    // Interval decides how often to show the notification, e.g. every 10 progresses.
+    // Interval must be > 0.
     sa_Achievement.isProgressVisible false;
+    sa_Achievement.isProgressVisibleInterval 1;
 
     // Hidden achievements don't show up in Locked achievement list, and are only
     // visible when are achieved.
@@ -159,7 +162,7 @@ extend class sa_Achiever
     {
     case STATE_UNLOCKED: addTask(me, achievement, false, 0); break;
     case STATE_PROGRESS:
-      if (achievement.isProgressVisible)
+      if (achievement.isProgressVisible && count % achievement.isProgressVisibleInterval == 0)
       {
         addTask(me, achievement, true,  count);
       }
@@ -312,6 +315,7 @@ extend class sa_Achievement
   int    limit;
   String progressTitle;
   bool   isProgressVisible;
+  int    isProgressVisibleInterval;
 
   int lifetime;
   int animationTime;
@@ -339,6 +343,7 @@ extend class sa_Achievement
   property limit         : limit;
   property progressTitle : progressTitle;
   property isProgressVisible : isProgressVisible;
+  property isProgressVisibleInterval : isProgressVisibleInterval;
   property lifetime      : lifetime;
   property animationTime : animationTime;
   property fontName      : fontName;

--- a/zscript/StupidAchievements.zs
+++ b/zscript/StupidAchievements.zs
@@ -513,7 +513,10 @@ class sa_Task abstract
 
   void start()
   {
-    S_StartSound(mSound,CHAN_AUTO,CHANF_UI);
+    if(mSoundEnabledCvar.getBool())
+    {
+      S_StartSound(mSound,CHAN_AUTO,CHANF_UI);
+    }
     mBirthTime = level.time;
   }
 
@@ -528,6 +531,7 @@ class sa_Task abstract
     mIcon    = sa_.switchIcon(achievement, isProgress);
     mSound   = sa_.switchSound(achievement, isProgress);
 
+    mSoundEnabledCvar       = sa_Cvar.of("sa_sound_enabled");
     mHorizontalPositionCvar = sa_Cvar.of("sa_horizontal_position");
     mVerticalPositionCvar   = sa_Cvar.of("sa_vertical_position");
   }
@@ -545,6 +549,7 @@ class sa_Task abstract
 
   protected sa_Cvar mHorizontalPositionCvar;
   protected sa_Cvar mVerticalPositionCvar;
+  protected sa_Cvar mSoundEnabledCvar;
 
 } // class sa_Task abstract
 

--- a/zscript/StupidAchievements.zs
+++ b/zscript/StupidAchievements.zs
@@ -366,6 +366,8 @@ class sa_TestAchievement : sa_Achievement
     sa_Achievement.isProgressVisible true;
     sa_Achievement.lockedIcon "sa_icon";
     sa_Achievement.unlockedIcon "sa_icon";
+    sa_Achievement.progressSound "misc/chat";
+    sa_Achievement.unlockSound "misc/secret";
   }
 } // class sa_TestAchievement
 


### PR DESCRIPTION
My favourite part of achievements in games is that satisfying sound, so I added this to the library.
As a preview I made the imp achievements use the gzdoom secret found sound effect for unlock.
Sounds can be disabled by the user in the options, and can be defined separately for progress notifications and unlock notifications of each achievement.
I also added intervals to progress notifications, so for example: 
There is an achievement for killing a thousand enemies. Showing a notification for every kill would be really annoying, but it would be nice to notify the player that they are getting closer to the goal from time to time, so it can be made to pop up every hundred kills.
As a preview I edited the 100 imp punches achievement to show a notification every 10 punches, with the Doom 2 radio sound.